### PR TITLE
Fix compilation

### DIFF
--- a/Laborantin/CLI.hs
+++ b/Laborantin/CLI.hs
@@ -138,7 +138,7 @@ matchersOpt = many $ strOption (
   <> metavar "MATCHERS"
   <> help "Matcher queries to specify the parameter space.")
 
-concurrencyLeveLOpt = option (
+concurrencyLeveLOpt = option auto (
      long "concurrency"
   <> short 'C'
   <> value 1

--- a/Laborantin/Query/Parse.hs
+++ b/Laborantin/Query/Parse.hs
@@ -14,6 +14,7 @@ import qualified Data.Text as T
 import Text.Parsec
 import Text.Parsec.Char
 import Text.Parsec.Combinator
+import Text.Parsec.Prim
 import Data.Maybe
 import System.Locale
 import Data.Time


### PR DESCRIPTION
optparse-applicative changed the "option" after 0.10 and the compiler couldn't find "runP", it seems to be in "Text.Parsec.Prim".
