### PR TITLE
Fix build. Now works with ghc-7.6, ghc-7.8 and ghc-7.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: haskell
+ghc:
+ - 7.6
+ - 7.8
+# Travis complains with:
+# ghc_find: error, no such version 7.1
+# - 7.10

--- a/Laborantin/CLI.hs
+++ b/Laborantin/CLI.hs
@@ -3,13 +3,16 @@
 {-# LANGUAGE FlexibleInstances, MultiParamTypeClasses #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE CPP #-}
 
 module Laborantin.CLI (defaultMain) where
 
 import Control.Exception (finally)
 import Options.Applicative
-import Data.Time (UTCTime(..), getCurrentTime)
-import System.Locale (defaultTimeLocale)
+import Data.Time
+#if !(MIN_VERSION_time(1,5,0))
+import System.Locale
+#endif
 import System.Exit (exitFailure)
 import System.Directory (doesFileExist)
 import Data.Text (Text)
@@ -138,7 +141,7 @@ matchersOpt = many $ strOption (
   <> metavar "MATCHERS"
   <> help "Matcher queries to specify the parameter space.")
 
-concurrencyLeveLOpt = option (
+concurrencyLeveLOpt = option auto (
      long "concurrency"
   <> short 'C'
   <> value 1

--- a/Laborantin/Implementation.hs
+++ b/Laborantin/Implementation.hs
@@ -230,7 +230,8 @@ loadExisting scs qexpr = do
             paths <- map (("results" </> name) </>) . filter notDot <$> liftIO (getDirectoryContents' $ "results" </> name)
             allExecs <- mapM (loadOne sc scs) paths
             return $ filter (matchTExpr qexpr) allExecs
-            where notDot dirname = take 1 dirname /= "."
+            where notDot :: FilePath -> Bool
+                  notDot dirname = take 1 dirname /= "."
                   name = T.unpack $ sName sc
 
                   getDirectoryContents' dir = catchIOError (getDirectoryContents dir)

--- a/Laborantin/Query/Parse.hs
+++ b/Laborantin/Query/Parse.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE CPP #-}
 
 module Laborantin.Query.Parse (
       expr
@@ -15,7 +17,9 @@ import Text.Parsec
 import Text.Parsec.Char
 import Text.Parsec.Combinator
 import Data.Maybe
+#if !(MIN_VERSION_time(1,5,0))
 import System.Locale
+#endif
 import Data.Time
 import Data.Time.Format
 

--- a/laborantin-hs.cabal
+++ b/laborantin-hs.cabal
@@ -63,16 +63,16 @@ library
   other-modules:       Laborantin.Query.Parse, Laborantin.Query.Interpret
   other-extensions:    FlexibleContexts, OverloadedStrings, TupleSections
   build-depends:
-    base >=4.6 && <4.8,
-    transformers >=0.3 && <0.4,
-    mtl >=2.1 && <2.2,
+    base >=4.6 && <4.9,
+    transformers >=0.3 && <0.5,
+    mtl >=2.1 && <2.3,
     containers >=0.5 && <0.6,
-    text >= 0.11 && <1.2,
+    text >= 0.11 && <1.3,
     bytestring >=0.10 && <0.11,
-    aeson >=0.7 && <0.8,
+    aeson >=0.7 && <0.9,
     uuid >=1.3 && <1.4,
     directory >=1.2 && <1.3,
-    random >=1.0 && <1.1,
+    random >=1.0 && <1.2,
     hslogger >=1.2 && <1.3,
     filepath >=1.0 && <1.5,
     split >= 0.2.2,
@@ -80,7 +80,7 @@ library
     parsec >= 3.1.0,
     old-locale >=1.0.0.5,
     async >= 2.0.1.0,
-    optparse-applicative >= 0.9.0
+    optparse-applicative >= 0.11.0 && < 0.12
   -- hs-source-dirs:      
   default-language:    Haskell2010
 
@@ -89,18 +89,18 @@ executable labor-example
   ghc-options: -Wall
   hs-source-dirs: examples
   build-depends:
-    base >=4.6 && <4.8,
-    transformers >=0.3 && <0.4,
-    mtl >=2.1 && <2.2,
+    base >=4.6 && <4.9,
+    transformers >=0.3 && <0.5,
+    mtl >=2.1 && <2.3,
     containers >=0.5 && <0.6,
-    text >=0.11 && <1.2,
+    text >=0.11 && <1.3,
     bytestring >=0.10 && <0.11,
-    aeson >=0.6 && <0.8,
+    aeson >=0.6 && <0.9,
     uuid >=1.3 && <1.4,
     directory >=1.2 && <1.3,
-    random >=1.0 && <1.1,
+    random >=1.0 && <1.2,
     hslogger >=1.2 && <1.3,
     split >= 0.2.2,
     laborantin-hs >= 0.1.5.1,
-    optparse-applicative >= 0.9.0
+    optparse-applicative >= 0.11.0 && < 0.12
   default-language:    Haskell2010

--- a/laborantin-hs.cabal
+++ b/laborantin-hs.cabal
@@ -62,7 +62,24 @@ library
   exposed-modules:     Laborantin, Laborantin.DSL, Laborantin.Implementation, Laborantin.Types, Laborantin.CLI, Laborantin.Query
   other-modules:       Laborantin.Query.Parse, Laborantin.Query.Interpret
   other-extensions:    FlexibleContexts, OverloadedStrings, TupleSections
-  build-depends:       base >=4.6 && <4.8, transformers >=0.3 && <0.4, mtl >=2.1 && <2.2, containers >=0.5 && <0.6, text >= 0.11 && <1.2, bytestring >=0.10 && <0.11, aeson >=0.7 && <0.8, uuid >=1.3 && <1.4, directory >=1.2 && <1.3, random >=1.0 && <1.1, hslogger >=1.2 && <1.3, split >= 0.2.2, time >= 1.4.0.1, parsec >= 3.1.0, old-locale >=1.0.0.5, async >= 2.0.1.0, optparse-applicative >= 0.9.0
+  build-depends:
+    base >=4.6 && <4.8,
+    transformers >=0.3 && <0.4,
+    mtl >=2.1 && <2.2,
+    containers >=0.5 && <0.6,
+    text >= 0.11 && <1.2,
+    bytestring >=0.10 && <0.11,
+    aeson >=0.7 && <0.8,
+    uuid >=1.3 && <1.4,
+    directory >=1.2 && <1.3,
+    random >=1.0 && <1.1,
+    hslogger >=1.2 && <1.3,
+    split >= 0.2.2,
+    time >= 1.4.0.1,
+    parsec >= 3.1.0,
+    old-locale >=1.0.0.5,
+    async >= 2.0.1.0,
+    optparse-applicative >= 0.9.0
   -- hs-source-dirs:      
   default-language:    Haskell2010
 
@@ -70,5 +87,19 @@ executable labor-example
   main-is: main.hs
   ghc-options: -Wall
   hs-source-dirs: examples
-  build-depends:       base >=4.6 && <4.8, transformers >=0.3 && <0.4, mtl >=2.1 && <2.2, containers >=0.5 && <0.6, text >=0.11 && <1.2, bytestring >=0.10 && <0.11, aeson >=0.6 && <0.8, uuid >=1.3 && <1.4, directory >=1.2 && <1.3, random >=1.0 && <1.1, hslogger >=1.2 && <1.3, split >= 0.2.2, laborantin-hs >= 0.1.5.1, optparse-applicative >= 0.9.0
+  build-depends:
+    base >=4.6 && <4.8,
+    transformers >=0.3 && <0.4,
+    mtl >=2.1 && <2.2,
+    containers >=0.5 && <0.6,
+    text >=0.11 && <1.2,
+    bytestring >=0.10 && <0.11,
+    aeson >=0.6 && <0.8,
+    uuid >=1.3 && <1.4,
+    directory >=1.2 && <1.3,
+    random >=1.0 && <1.1,
+    hslogger >=1.2 && <1.3,
+    split >= 0.2.2,
+    laborantin-hs >= 0.1.5.1,
+    optparse-applicative >= 0.9.0
   default-language:    Haskell2010

--- a/laborantin-hs.cabal
+++ b/laborantin-hs.cabal
@@ -74,6 +74,7 @@ library
     directory >=1.2 && <1.3,
     random >=1.0 && <1.1,
     hslogger >=1.2 && <1.3,
+    filepath >=1.0 && <1.5,
     split >= 0.2.2,
     time >= 1.4.0.1,
     parsec >= 3.1.0,


### PR DESCRIPTION
* the optparse-applicative API changed, and the .cabal file didn't specify an upper bound.
* the module `Data.Time.Format` from the time package started exporting the same functions as `System.Locale` from old-locale. I added some CPP to workaround this.

I also added a .travis.yml file that make sure that this packages can still be built with ghc-7.6 and ghc-7.8.

Edit: also fix the following error with ghc-7.10 by adding a `FlexibleContexts` pragma to Parse.hs:

```
Laborantin/Query/Parse.hs:46:1:
    Non type-variable argument in the constraint: Stream s m Char
    (Use FlexibleContexts to permit this)
    When checking that ‘binOp’ has the inferred type
      binOp :: forall s u (m :: * -> *) r.
               Stream s m Char =>
               [(String, r)] -> ParsecT s u m r
```